### PR TITLE
Add cmdbuild 3.3 images

### DIFF
--- a/3.3/cmdbuild/Dockerfile
+++ b/3.3/cmdbuild/Dockerfile
@@ -1,0 +1,55 @@
+FROM tomcat:9.0.31-jdk11-openjdk
+
+MAINTAINER LLC Itmicus <order@itmicus.ru>
+
+WORKDIR $CATALINA_HOME
+
+ENV CMDBUILD_URL https://sourceforge.net/projects/cmdbuild/files/3.3/cmdbuild-3.3.war/download
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASS postgres
+ENV POSTGRES_PORT 5432
+ENV POSTGRES_HOST cmdbuild_db
+ENV POSTGRES_DB cmdbuild_db3
+ENV CMDBUILD_DUMP demo
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+    maven \
+	postgresql-client
+
+RUN set -x \
+ 	&& mkdir $CATALINA_HOME/conf/cmdbuild/ \
+ 	&& mkdir $CATALINA_HOME/webapps/cmdbuild/
+
+COPY files/tomcat-users.xml $CATALINA_HOME/conf/tomcat-users.xml
+COPY files/context.xml $CATALINA_HOME/webapps/manager/META-INF/context.xml
+COPY files/database.conf $CATALINA_HOME/conf/cmdbuild/database.conf
+COPY files/docker-entrypoint.sh /usr/local/bin/
+
+
+RUN set -x \
+	&& groupadd tomcat \
+	&& useradd -s /bin/false -g tomcat -d $CATALINA_HOME tomcat \
+	&& cd /tmp \
+	&& wget -O cmdbuild.war "$CMDBUILD_URL" \
+	&& chmod 777 cmdbuild.war \
+	&& chmod 777 /usr/local/bin/docker-entrypoint.sh \
+	&& unzip cmdbuild.war -d cmdbuild \
+	&& mv cmdbuild.war $CATALINA_HOME/webapps/cmdbuild.war \
+	&& mv cmdbuild/* $CATALINA_HOME/webapps/cmdbuild/ \
+	&& chmod 777 $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh \
+	&& chown tomcat -R $CATALINA_HOME \
+	&& cd /tmp \
+	&& rm -rf * \
+	&& rm -rf /var/lib/apt/lists/*
+
+# cleanup
+RUN apt-get -qy autoremove
+
+ENTRYPOINT /usr/local/bin/docker-entrypoint.sh
+
+USER tomcat
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/3.3/cmdbuild/files/context.xml
+++ b/3.3/cmdbuild/files/context.xml
@@ -1,0 +1,5 @@
+<Context antiResourceLocking="false" privileged="true" >
+    <!-- <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" /> -->
+    <Manager sessionAttributeValueClassNameFilter="java\.lang\.(?:Boolean|Integer|Long|Number|String)|org\.apache\.catalina\.filters\.CsrfPreventionFilter\$LruCache(?:\$1)?|java\.util\.(?:Linked)?HashMap"/>
+</Context>

--- a/3.3/cmdbuild/files/database.conf
+++ b/3.3/cmdbuild/files/database.conf
@@ -1,0 +1,5 @@
+db.url=jdbc:postgresql://cmdbuild_db:5432/cmdbuild_30
+db.username=cmdbuild
+db.password=cmdbuild
+db.admin.username=postgres
+db.admin.password=postgres

--- a/3.3/cmdbuild/files/docker-entrypoint.sh
+++ b/3.3/cmdbuild/files/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+cat /dev/null > $CATALINA_HOME/conf/cmdbuild/database.conf
+echo "Edit $CATALINA_HOME/conf/cmdbuild/database.conf"
+{
+    echo "db.url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+    echo "db.username=cmdbuild"
+    echo "db.password=cmdbuild"
+    echo "db.admin.username=$POSTGRES_USER"
+    echo "db.admin.password=$POSTGRES_PASS"
+} >> $CATALINA_HOME/conf/cmdbuild/database.conf
+
+# first init DB, second start with fail
+while ! timeout 1 bash -c "echo > /dev/tcp/$POSTGRES_HOST/$POSTGRES_PORT"; do   
+  >&2 echo "Postgres is unavailable - sleeping" 
+  sleep 5
+done
+
+echo "Init DB"
+{ # try
+  
+    $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh dbconfig create $CMDBUILD_DUMP -configfile $CATALINA_HOME/conf/cmdbuild/database.conf
+   
+} || { 
+    echo "DB was initiliazed. Use dbconfig recreate or dbconfig drop"
+}
+
+#echo "Change user to tomcat"
+#su tomcat
+
+#echo "RUN catalina"
+exec $CATALINA_HOME/bin/catalina.sh run

--- a/3.3/cmdbuild/files/tomcat-users.xml
+++ b/3.3/cmdbuild/files/tomcat-users.xml
@@ -1,0 +1,6 @@
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+  <user username="admin" password="password" roles="manager-gui"/>
+</tomcat-users>

--- a/3.3/docker-compose.yml
+++ b/3.3/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
     cmdbuild_db:
-        image: itmicus/cmdbuild:db-3.3
+        image: itmicus/cmdbuild:db-3.0
         container_name: cmdbuild_db
         volumes:
             - cmdbuild-db:/var/lib/postgresql

--- a/3.3/docker-compose.yml
+++ b/3.3/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "2.4"
+volumes:
+    cmdbuild-db:
+    cmdbuild-tomcat:
+
+services:
+    cmdbuild_db:
+        image: itmicus/cmdbuild:db-3.3
+        container_name: cmdbuild_db
+        volumes:
+            - cmdbuild-db:/var/lib/postgresql
+        ports:
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+        restart: always
+        mem_limit: 1000m
+        mem_reservation: 300m
+
+    cmdbuild_app:
+        image: itmicus/cmdbuild:app-3.3
+        container_name: cmdbuild_app
+        links:
+           - cmdbuild_db
+        depends_on:
+           - cmdbuild_db
+        ports:
+            - 8090:8080
+        restart: always  
+        volumes:
+            - cmdbuild-tomcat:/usr/local/tomcat
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+            - POSTGRES_PORT=5432
+            - POSTGRES_HOST=cmdbuild_db
+            - POSTGRES_DB=cmdbuild_3
+            - CMDBUILD_DUMP=demo
+            - JAVA_OPTS=-Xmx4000m -Xms2000m
+        mem_limit: 4000m
+        mem_reservation: 2000m

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMDBuild 3.2 with READY2USE 2.0 and openMAINT 2.0 in Docker
+# CMDBuild 3.3 with READY2USE 2.0 and openMAINT 2.0 in Docker
 
 ![cmdbuild_logo](https://www.tecnoteca.com/immagini/logo_cmdbuild.png/@@images/bf2e13f9-7a90-4e41-ba76-cf8fe5a87d50.png)  
 [CMDBuild](http://www.cmdbuild.org/en) is a web environment in which you can configure custom solutions for IT Governance, or more generally for asset management.  

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [openMaint](http://www.openmaint.org) open source solution for the Property & Facility Management; an application for the management of buildings, installations, movable assets and related maintenance activities  
 
 ## Latest news
+**12/10/2020** Add CMDBuild 3.3, READY2USE 2.0 and openMAINT 2.0 on CMDBuild 3.2.1  -- @afcarvalho1991 contribution
 **11/06/2020** Add CMDBuild 3.2.1, READY2USE 2.0 and openMAINT 2.0 on CMDBuild 3.2.1  
 **19/02/2020** Add CMDBuild 3.2, READY2USE 2.0 and openMAINT 2.0 on CMDBuild 3.2  
 **27/10/2019** Add CMDBuild 3.1.1, READY2USE 2.0 and openMAINT 2.0 on CMDBuild 3.1.1  
@@ -27,21 +28,25 @@ I will update the repository every time there is a new version of cmdbuild avail
 
 ```bash
 docker run --name cmdbuild_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
-docker run --name cmdbuild_app --restart unless-stopped --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:app-3.2.1
+docker run --name cmdbuild_app --restart unless-stopped --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:app-3.3
 ```
+
+### Build images (locally)
+
+    sh docker-build.sh # or select the specific version needed and the DB image
 
 ### CMDbuild READY2USE 2.0
 
 ```bash
 docker run --name cmdbuild_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
-docker run --name cmdbuild_app --restart unless-stopped -e CMDBUILD_DUMP="demo.dump.xz" --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:r2u-2.0-3.2.1
+docker run --name cmdbuild_app --restart unless-stopped -e CMDBUILD_DUMP="demo.dump.xz" --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:r2u-2.0-3.3
 ```
   
 ### CMDbuild openMAINT 2.0
 
 ```bash
 docker run --name openmaint_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
-docker run --name openmaint_app --restart unless-stopped -e CMDBUILD_DUMP="demo.dump.xz" --link openmaint_db  -p 8090:8080 -d itmicus/cmdbuild:om-2.0-3.2.1
+docker run --name openmaint_app --restart unless-stopped -e CMDBUILD_DUMP="demo.dump.xz" --link openmaint_db  -p 8090:8080 -d itmicus/cmdbuild:om-2.0-3.3
 ```
 
 ## Deploy by docker-compose

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,6 +2,7 @@
 
 # build images and set tags
 # cmdbuild
+docker build -t itmicus/cmdbuild:app-3.3 3.3/cmdbuild/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:app-3.2.1 3.2.1/cmdbuild/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:app-3.2 3.2/cmdbuild/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:app-3.1.1 3.1.1/cmdbuild/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -16,5 +16,6 @@ docker build -t itmicus/cmdbuild:r2u-2.0-3.1.1 ready2use-2.0-3.1.1/. --label "ve
 docker build -t itmicus/cmdbuild:r2u-2.0 ready2use-2.0/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 
 #openMAINT
+docker build -t itmicus/cmdbuild:om-2.0-3.3 openmaint-2.0-3.3/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:om-2.0-3.2.1 openmaint-2.0-3.2.1/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:om-2.0-3.2 openmaint-2.0-3.2/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -10,6 +10,7 @@ docker build -t itmicus/cmdbuild:app-3.1 3.1/cmdbuild/. --label "version=1.0" --
 docker build -t itmicus/cmdbuild:db-3.0 3.0/postgres/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 
 # ready2use
+docker build -t itmicus/cmdbuild:r2u-2.0-3.3 ready2use-2.0-3.3/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:r2u-2.0-3.2.1 ready2use-2.0-3.2.1/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:r2u-2.0-3.2 ready2use-2.0-3.2/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"
 docker build -t itmicus/cmdbuild:r2u-2.0-3.1.1 ready2use-2.0-3.1.1/. --label "version=1.0" --label "maintaner=Itmicus <order@itmicus.ru>"

--- a/openmaint-2.0-3.3/Dockerfile
+++ b/openmaint-2.0-3.3/Dockerfile
@@ -1,0 +1,55 @@
+FROM tomcat:9.0.31-jdk11-openjdk
+
+MAINTAINER LLC Itmicus <order@itmicus.ru>
+
+WORKDIR $CATALINA_HOME
+
+ENV CMDBUILD_URL https://sourceforge.net/projects/openmaint/files/2.0/Core%20updates/openmaint-2.0-3.3/openmaint-2.0-3.3.war/download
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASS postgres
+ENV POSTGRES_PORT 5432
+ENV POSTGRES_HOST openmaint_db
+ENV POSTGRES_DB openmaint
+ENV CMDBUILD_DUMP demo.dump.xz
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+    maven \
+	postgresql-client
+
+RUN set -x \
+ 	&& mkdir $CATALINA_HOME/conf/cmdbuild/ \
+ 	&& mkdir $CATALINA_HOME/webapps/cmdbuild/
+
+COPY files/tomcat-users.xml $CATALINA_HOME/conf/tomcat-users.xml
+COPY files/context.xml $CATALINA_HOME/webapps/manager/META-INF/context.xml
+COPY files/database.conf $CATALINA_HOME/conf/cmdbuild/database.conf
+COPY files/docker-entrypoint.sh /usr/local/bin/
+
+
+RUN set -x \
+	&& groupadd tomcat \
+	&& useradd -s /bin/false -g tomcat -d $CATALINA_HOME tomcat \
+	&& cd /tmp \
+	&& wget -O cmdbuild.war "$CMDBUILD_URL" \
+	&& chmod 777 cmdbuild.war \
+	&& chmod 777 /usr/local/bin/docker-entrypoint.sh \
+	&& unzip cmdbuild.war -d cmdbuild \
+	&& mv cmdbuild.war $CATALINA_HOME/webapps/cmdbuild.war \
+	&& mv cmdbuild/* $CATALINA_HOME/webapps/cmdbuild/ \
+	&& chmod 777 $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh \
+	&& chown tomcat -R $CATALINA_HOME \
+	&& cd /tmp \
+	&& rm -rf * \
+	&& rm -rf /var/lib/apt/lists/*
+
+# cleanup
+RUN apt-get -qy autoremove
+
+ENTRYPOINT /usr/local/bin/docker-entrypoint.sh
+
+USER tomcat
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/openmaint-2.0-3.3/docker-compose.yml
+++ b/openmaint-2.0-3.3/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "2.4"
+volumes:
+    openmaint-db:
+    openmaint-tomcat:
+
+services:
+    openmaint_db:
+        image: itmicus/cmdbuild:db-3.0
+        container_name: openmaint_db
+        volumes:
+            - openmaint-db:/var/lib/postgresql
+        ports:
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+        restart: always
+        mem_limit: 1000m
+        mem_reservation: 300m
+
+    openmaint_app:
+        image: itmicus/cmdbuild:om-2.0-3.3
+        container_name: openmaint_app
+        links:
+           - openmaint_db
+        depends_on:
+           - openmaint_db
+        ports:
+            - 8090:8080
+        restart: always
+        volumes:
+            - openmaint-tomcat:/usr/local/tomcat
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+            - POSTGRES_PORT=5432
+            - POSTGRES_HOST=openmaint_db
+            - POSTGRES_DB=openmaint
+            - CMDBUILD_DUMP=demo.dump.xz
+            - JAVA_OPTS=-Xmx4000m -Xms2000m
+        mem_limit: 4000m
+        mem_reservation: 2000m

--- a/openmaint-2.0-3.3/files/context.xml
+++ b/openmaint-2.0-3.3/files/context.xml
@@ -1,0 +1,5 @@
+<Context antiResourceLocking="false" privileged="true" >
+    <!-- <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" /> -->
+    <Manager sessionAttributeValueClassNameFilter="java\.lang\.(?:Boolean|Integer|Long|Number|String)|org\.apache\.catalina\.filters\.CsrfPreventionFilter\$LruCache(?:\$1)?|java\.util\.(?:Linked)?HashMap"/>
+</Context>

--- a/openmaint-2.0-3.3/files/database.conf
+++ b/openmaint-2.0-3.3/files/database.conf
@@ -1,0 +1,5 @@
+db.url=jdbc:postgresql://openmaint_db:5432/openmaint
+db.username=openmaint
+db.password=openmaint
+db.admin.username=postgres
+db.admin.password=postgres

--- a/openmaint-2.0-3.3/files/docker-entrypoint.sh
+++ b/openmaint-2.0-3.3/files/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+cat /dev/null > $CATALINA_HOME/conf/cmdbuild/database.conf
+echo "Edit $CATALINA_HOME/conf/cmdbuild/database.conf"
+{
+    echo "db.url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+    echo "db.username=openmaint"
+    echo "db.password=openmaint"
+    echo "db.admin.username=$POSTGRES_USER"
+    echo "db.admin.password=$POSTGRES_PASS"
+} >> $CATALINA_HOME/conf/cmdbuild/database.conf
+
+# first init DB, second start with fail
+while ! timeout 1 bash -c "echo > /dev/tcp/$POSTGRES_HOST/$POSTGRES_PORT"; do   
+  >&2 echo "Postgres is unavailable - sleeping" 
+  sleep 5
+done
+
+echo "Init DB"
+{ # try
+  
+    $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh dbconfig create $CMDBUILD_DUMP -configfile $CATALINA_HOME/conf/cmdbuild/database.conf
+   
+} || { 
+    echo "DB was initiliazed. Use dbconfig recreate or dbconfig drop"
+}
+
+#echo "Change user to tomcat"
+#su tomcat
+
+#echo "RUN catalina"
+exec $CATALINA_HOME/bin/catalina.sh run

--- a/openmaint-2.0-3.3/files/tomcat-users.xml
+++ b/openmaint-2.0-3.3/files/tomcat-users.xml
@@ -1,0 +1,6 @@
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+  <user username="admin" password="password" roles="manager-gui"/>
+</tomcat-users>

--- a/openmaint-2.0-3.3/readme.md
+++ b/openmaint-2.0-3.3/readme.md
@@ -1,0 +1,10 @@
+### Deploy by docker run
+**openMAINT with demo database**  
+```bash
+docker run --name openmaint_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
+docker run --name openmaint_app --restart unless-stopped -e CMDBUILD_DUMP="demo.dump.xz" --link openmaint_db  -p 8090:8080 -d itmicus/cmdbuild:om-2.0-3.3
+```  
+
+#### CMDBUILD_DUMP values
+* demo.dump.xz
+* empty.dump.xz

--- a/ready2use-2.0-3.3/Dockerfile
+++ b/ready2use-2.0-3.3/Dockerfile
@@ -1,0 +1,55 @@
+FROM tomcat:9.0.31-jdk11-openjdk
+
+MAINTAINER LLC Itmicus <order@itmicus.ru>
+
+WORKDIR $CATALINA_HOME
+
+ENV CMDBUILD_URL https://sourceforge.net/projects/cmdbuild/files/ready2use-2.0/Core%20updates/ready2use-2.0-3.3/ready2use-2.0-3.3.war/download
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASS postgres
+ENV POSTGRES_PORT 5432
+ENV POSTGRES_HOST cmdbuild_db
+ENV POSTGRES_DB cmdbuild_r2u2
+ENV CMDBUILD_DUMP ready2use_demo.dump.xz
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+    maven \
+	postgresql-client
+
+RUN set -x \
+ 	&& mkdir $CATALINA_HOME/conf/cmdbuild/ \
+ 	&& mkdir $CATALINA_HOME/webapps/cmdbuild/
+
+COPY files/tomcat-users.xml $CATALINA_HOME/conf/tomcat-users.xml
+COPY files/context.xml $CATALINA_HOME/webapps/manager/META-INF/context.xml
+COPY files/database.conf $CATALINA_HOME/conf/cmdbuild/database.conf
+COPY files/docker-entrypoint.sh /usr/local/bin/
+
+
+RUN set -x \
+	&& groupadd tomcat \
+	&& useradd -s /bin/false -g tomcat -d $CATALINA_HOME tomcat \
+	&& cd /tmp \
+	&& wget -O cmdbuild.war "$CMDBUILD_URL" \
+	&& chmod 777 cmdbuild.war \
+	&& chmod 777 /usr/local/bin/docker-entrypoint.sh \
+	&& unzip cmdbuild.war -d cmdbuild \
+	&& mv cmdbuild.war $CATALINA_HOME/webapps/cmdbuild.war \
+	&& mv cmdbuild/* $CATALINA_HOME/webapps/cmdbuild/ \
+	&& chmod 777 $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh \
+	&& chown tomcat -R $CATALINA_HOME \
+	&& cd /tmp \
+	&& rm -rf * \
+	&& rm -rf /var/lib/apt/lists/*
+
+# cleanup
+RUN apt-get -qy autoremove
+
+ENTRYPOINT /usr/local/bin/docker-entrypoint.sh
+
+USER tomcat
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/ready2use-2.0-3.3/docker-compose.yml
+++ b/ready2use-2.0-3.3/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "2.4"
+volumes:
+    cmdbuild-db:
+    cmdbuild-tomcat:
+
+services:
+    cmdbuild_db:
+        image: itmicus/cmdbuild:db-3.0
+        container_name: cmdbuild_db
+        volumes:
+            - cmdbuild-db:/var/lib/postgresql
+        ports:
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+        restart: always
+        mem_limit: 1000m
+        mem_reservation: 300m
+
+    cmdbuild_app:
+        image: itmicus/cmdbuild:r2u-2.0-3.3
+        container_name: cmdbuild_app
+        links:
+           - cmdbuild_db
+        depends_on:
+           - cmdbuild_db
+        ports:
+            - 8090:8080
+        restart: always
+        volumes:
+            - cmdbuild-tomcat:/usr/local/tomcat
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASS=postgres
+            - POSTGRES_PORT=5432
+            - POSTGRES_HOST=cmdbuild_db
+            - POSTGRES_DB=cmdbuild_r2u2
+            - CMDBUILD_DUMP=demo.dump.xz
+            - JAVA_OPTS=-Xmx4000m -Xms2000m
+        mem_limit: 4000m
+        mem_reservation: 2000m

--- a/ready2use-2.0-3.3/files/context.xml
+++ b/ready2use-2.0-3.3/files/context.xml
@@ -1,0 +1,5 @@
+<Context antiResourceLocking="false" privileged="true" >
+    <!-- <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="127\.\d+\.\d+\.\d+|::1|0:0:0:0:0:0:0:1" /> -->
+    <Manager sessionAttributeValueClassNameFilter="java\.lang\.(?:Boolean|Integer|Long|Number|String)|org\.apache\.catalina\.filters\.CsrfPreventionFilter\$LruCache(?:\$1)?|java\.util\.(?:Linked)?HashMap"/>
+</Context>

--- a/ready2use-2.0-3.3/files/database.conf
+++ b/ready2use-2.0-3.3/files/database.conf
@@ -1,0 +1,5 @@
+db.url=jdbc:postgresql://cmdbuild_db:5432/cmdbuild_r2u2
+db.username=cmdbuild
+db.password=cmdbuild
+db.admin.username=postgres
+db.admin.password=postgres

--- a/ready2use-2.0-3.3/files/docker-entrypoint.sh
+++ b/ready2use-2.0-3.3/files/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+cat /dev/null > $CATALINA_HOME/conf/cmdbuild/database.conf
+echo "Edit $CATALINA_HOME/conf/cmdbuild/database.conf"
+{
+    echo "db.url=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+    echo "db.username=cmdbuild"
+    echo "db.password=cmdbuild"
+    echo "db.admin.username=$POSTGRES_USER"
+    echo "db.admin.password=$POSTGRES_PASS"
+} >> $CATALINA_HOME/conf/cmdbuild/database.conf
+
+# first init DB, second start with fail
+while ! timeout 1 bash -c "echo > /dev/tcp/$POSTGRES_HOST/$POSTGRES_PORT"; do   
+  >&2 echo "Postgres is unavailable - sleeping" 
+  sleep 5
+done
+
+echo "Init DB"
+{ # try
+  
+    $CATALINA_HOME/webapps/cmdbuild/cmdbuild.sh dbconfig create $CMDBUILD_DUMP -configfile $CATALINA_HOME/conf/cmdbuild/database.conf
+   
+} || { 
+    echo "DB was initiliazed. Use dbconfig recreate or dbconfig drop"
+}
+
+#echo "Change user to tomcat"
+#su tomcat
+
+#echo "RUN catalina"
+exec $CATALINA_HOME/bin/catalina.sh run

--- a/ready2use-2.0-3.3/files/tomcat-users.xml
+++ b/ready2use-2.0-3.3/files/tomcat-users.xml
@@ -1,0 +1,6 @@
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+  <user username="admin" password="password" roles="manager-gui"/>
+</tomcat-users>

--- a/ready2use-2.0-3.3/readme.md
+++ b/ready2use-2.0-3.3/readme.md
@@ -1,0 +1,16 @@
+### Deploy by docker run
+**CMDbuild with demo database**  
+```bash
+docker run --name cmdbuild_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
+docker run --name cmdbuild_app --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:app-3.3
+```
+
+**CMDbuild Ready2use 2.0**  
+```bash  
+docker run --name cmdbuild_db -p 5432:5432 -d itmicus/cmdbuild:db-3.0
+docker run --name cmdbuild_app --restart unless-stopped -e CMDBUILD_DUMP="ready2use_demo.dump.xz" --link cmdbuild_db  -p 8090:8080 -d itmicus/cmdbuild:r2u-2.0-3.3
+```  
+
+#### CMDBUILD_DUMP values
+* demo.dump.xz
+* empty.dump.xz


### PR DESCRIPTION
Integrated  Docker images using cmdbuild 3.3 to:
 - CMDBuild 
 - READY2USE 2.0 
 - openMAINT 2.0

Still requires @itmicus to locally build and publish these images to docker-hub.